### PR TITLE
fill in more record types

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Main todos:
   - store as file. SQLite files can never be pure streaming, since we need to
     write some stuff at the beginning of the file once we have all the data,
     but a temp file would work, and then there are no memory restrictions anymore.
+  - check if "1.4. The Lock-Byte Page" is relevant
 
 What this library won't do:
   - add indexes. (but every row gets an internal "row id", which we could

--- a/bakelite.go
+++ b/bakelite.go
@@ -30,6 +30,7 @@ func New() *DB {
 //   - int
 //   - float64
 //   - string
+//   - []byte
 //   - nil
 // (yup, that's all for now)
 //

--- a/bakelite.go
+++ b/bakelite.go
@@ -28,6 +28,7 @@ func New() *DB {
 //
 // Supported Go datatypes:
 //   - int
+//   - float64
 //   - string
 //   - nil
 // (yup, that's all for now)

--- a/bakelite_test.go
+++ b/bakelite_test.go
@@ -83,12 +83,17 @@ func TestValues(t *testing.T) {
 		{-0.0},
 		{-3.1415},
 	})
+	db.AddSlice("bytes", []string{"value"}, [][]any{
+		{[]byte("foo")},
+		{[]byte("bar")},
+		{"hello"},
+	})
 
 	b := &bytes.Buffer{}
 	ok(t, db.WriteTo(b))
 	file := saveFile(t, b, "values.sqlite")
 
-	sqlite(t, file, ".tables", "floats  ints  \n")
+	sqlite(t, file, ".tables", "bytes   floats  ints  \n")
 	sqlite(t, file, "SELECT value FROM ints ORDER BY value",
 		`-2147483649
 -2147483648
@@ -108,12 +113,20 @@ func TestValues(t *testing.T) {
 2147483648
 `,
 	)
+
 	sqlite(t, file, "SELECT value FROM floats ORDER BY value",
 		`-3.1415
 0.0
 0.0
 3.1415
 31415926535.89
+`,
+	)
+
+	sqlite(t, file, "SELECT value FROM bytes ORDER BY value",
+		`hello
+bar
+foo
 `,
 	)
 }

--- a/bakelite_test.go
+++ b/bakelite_test.go
@@ -58,7 +58,7 @@ func TestAFewRows(t *testing.T) {
 
 func TestValues(t *testing.T) {
 	db := New()
-	db.AddSlice("vals", []string{"value"}, [][]any{
+	db.AddSlice("ints", []string{"value"}, [][]any{
 		{-2147483649},
 		{-2147483648},
 		{-32769},
@@ -76,13 +76,20 @@ func TestValues(t *testing.T) {
 		{2147483647},
 		{2147483648},
 	})
+	db.AddSlice("floats", []string{"value"}, [][]any{
+		{31415926535.89},
+		{3.1415},
+		{0.0},
+		{-0.0},
+		{-3.1415},
+	})
 
 	b := &bytes.Buffer{}
 	ok(t, db.WriteTo(b))
 	file := saveFile(t, b, "values.sqlite")
 
-	sqlite(t, file, ".tables", "vals\n")
-	sqlite(t, file, "SELECT value FROM vals ORDER BY value",
+	sqlite(t, file, ".tables", "floats  ints  \n")
+	sqlite(t, file, "SELECT value FROM ints ORDER BY value",
 		`-2147483649
 -2147483648
 -32769
@@ -99,6 +106,14 @@ func TestValues(t *testing.T) {
 32768
 2147483647
 2147483648
+`,
+	)
+	sqlite(t, file, "SELECT value FROM floats ORDER BY value",
+		`-3.1415
+0.0
+0.0
+3.1415
+31415926535.89
 `,
 	)
 }

--- a/bakelite_test.go
+++ b/bakelite_test.go
@@ -56,6 +56,53 @@ func TestAFewRows(t *testing.T) {
 	sqlite(t, file, "SELECT name FROM planets ORDER BY moons", "Mercury\nVenus\nEarth\nMars\nNeptune\nUranus\nJupiter\nSaturn\n")
 }
 
+func TestValues(t *testing.T) {
+	db := New()
+	db.AddSlice("vals", []string{"value"}, [][]any{
+		{-2147483649},
+		{-2147483648},
+		{-32769},
+		{-32768},
+		{-129},
+		{-128},
+		{-1},
+		{0},
+		{1},
+		{2},
+		{127},
+		{128},
+		{32767},
+		{32768},
+		{2147483647},
+		{2147483648},
+	})
+
+	b := &bytes.Buffer{}
+	ok(t, db.WriteTo(b))
+	file := saveFile(t, b, "values.sqlite")
+
+	sqlite(t, file, ".tables", "vals\n")
+	sqlite(t, file, "SELECT value FROM vals ORDER BY value",
+		`-2147483649
+-2147483648
+-32769
+-32768
+-129
+-128
+-1
+0
+1
+2
+127
+128
+32767
+32768
+2147483647
+2147483648
+`,
+	)
+}
+
 func TestOverflow(t *testing.T) {
 	// single table, very long rows.
 	db := New()

--- a/db.go
+++ b/db.go
@@ -1,7 +1,7 @@
 package bakelite
 
 import (
-	"encoding/binary"
+	"github.com/alicebob/bakelite/internal"
 )
 
 type DB struct {
@@ -83,7 +83,7 @@ func (db *DB) storeOverflow(b []byte) int {
 
 	car, cdr := b[:PageSize-4], b[PageSize-4:]
 	nextID := db.storeOverflow(cdr)
-	binary.BigEndian.PutUint32(page, uint32(nextID))
+	internal.PutUint32(page, uint32(nextID))
 	copy(page[4:], car)
 	return db.addPage(page)
 }

--- a/internal/bits.go
+++ b/internal/bits.go
@@ -62,7 +62,6 @@ func PutUvarint(p []byte, v uint64) int {
 
 var PutUint16 = binary.BigEndian.PutUint16
 var PutUint32 = binary.BigEndian.PutUint32
-var PutUint64 = binary.BigEndian.PutUint64
 
 // Read a 24 bits two-complement integer.
 // b needs to be at least 3 bytes long

--- a/record.go
+++ b/record.go
@@ -47,6 +47,11 @@ func makeRecord(row []any) ([]byte, error) {
 					return nil, err
 				}
 			}
+		case float64:
+			p += internal.PutUvarint(header[p:], 7)
+			if err := binary.Write(body, binary.BigEndian, math.Float64bits(v)); err != nil {
+				return nil, err
+			}
 		case string:
 			l := 13 + 2*len(v)
 			p += internal.PutUvarint(header[p:], uint64(l))

--- a/record.go
+++ b/record.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/binary"
 	"fmt"
+	"math"
 
 	"github.com/alicebob/bakelite/internal"
 )
@@ -18,13 +19,29 @@ func makeRecord(row []any) ([]byte, error) {
 	for _, col := range row {
 		switch v := col.(type) {
 		case int:
-			switch v {
-			case 0:
+			switch {
+			case v == 0:
 				p += internal.PutUvarint(header[p:], 8)
-			case 1:
+			case v == 1:
 				p += internal.PutUvarint(header[p:], 9)
+			case v >= math.MinInt8 && v <= math.MaxInt8:
+				p += internal.PutUvarint(header[p:], 1)
+				if err := binary.Write(body, binary.BigEndian, int8(v)); err != nil {
+					return nil, err
+				}
+			case v >= math.MinInt16 && v <= math.MaxInt16:
+				p += internal.PutUvarint(header[p:], 2)
+				if err := binary.Write(body, binary.BigEndian, int16(v)); err != nil {
+					return nil, err
+				}
+				// skipped Int24 (type 3)
+			case v >= math.MinInt32 && v <= math.MaxInt32:
+				p += internal.PutUvarint(header[p:], 4)
+				if err := binary.Write(body, binary.BigEndian, int32(v)); err != nil {
+					return nil, err
+				}
+				// skipped Int48 (type 5)
 			default:
-				// TODO: we make it a 64bit number, but we should pick the smallest possible one
 				p += internal.PutUvarint(header[p:], 6)
 				if err := binary.Write(body, binary.BigEndian, int64(v)); err != nil {
 					return nil, err

--- a/record.go
+++ b/record.go
@@ -52,6 +52,10 @@ func makeRecord(row []any) ([]byte, error) {
 			if err := binary.Write(body, binary.BigEndian, math.Float64bits(v)); err != nil {
 				return nil, err
 			}
+		case []byte:
+			l := 12 + 2*len(v)
+			p += internal.PutUvarint(header[p:], uint64(l))
+			body.Write(v)
 		case string:
 			l := 13 + 2*len(v)
 			p += internal.PutUvarint(header[p:], uint64(l))

--- a/record_test.go
+++ b/record_test.go
@@ -79,6 +79,16 @@ func TestRecord(t *testing.T) {
 		eq(t, 1<<62, rec[0].(int64))
 	})
 
+	t.Run("float 64", func(t *testing.T) {
+		bs, err := makeRecord([]any{3.1415})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 3.1415, rec[0].(float64))
+	})
+
 	t.Run("simple string", func(t *testing.T) {
 		bs, err := makeRecord([]any{"hello"})
 		ok(t, err)

--- a/record_test.go
+++ b/record_test.go
@@ -99,6 +99,16 @@ func TestRecord(t *testing.T) {
 		eq(t, "hello", rec[0].(string))
 	})
 
+	t.Run("bytes", func(t *testing.T) {
+		bs, err := makeRecord([]any{[]byte("hello")})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, []byte("hello"), rec[0].([]byte))
+	})
+
 	t.Run("special case: 0", func(t *testing.T) {
 		bs, err := makeRecord([]any{0})
 		ok(t, err)

--- a/record_test.go
+++ b/record_test.go
@@ -19,7 +19,7 @@ func TestRecord(t *testing.T) {
 		eq(t, 0, len(rec))
 	})
 
-	t.Run("simple int", func(t *testing.T) {
+	t.Run("8-bit int", func(t *testing.T) {
 		bs, err := makeRecord([]any{42})
 		ok(t, err)
 
@@ -27,6 +27,56 @@ func TestRecord(t *testing.T) {
 		ok(t, err)
 		eq(t, 1, len(rec))
 		eq(t, 42, rec[0].(int64))
+	})
+
+	t.Run("16-bit int", func(t *testing.T) {
+		bs, err := makeRecord([]any{1 << 14})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 1<<14, rec[0].(int64))
+	})
+
+	t.Run("24-bit int", func(t *testing.T) {
+		bs, err := makeRecord([]any{1 << 20})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 1<<20, rec[0].(int64))
+	})
+
+	t.Run("32-bit int", func(t *testing.T) {
+		bs, err := makeRecord([]any{1 << 30})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 1<<30, rec[0].(int64))
+	})
+
+	t.Run("48-bit int", func(t *testing.T) {
+		bs, err := makeRecord([]any{1 << 45})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 1<<45, rec[0].(int64))
+	})
+
+	t.Run("64-bit int", func(t *testing.T) {
+		bs, err := makeRecord([]any{1 << 62})
+		ok(t, err)
+
+		rec, err := internal.ParseRecord(bs)
+		ok(t, err)
+		eq(t, 1, len(rec))
+		eq(t, 1<<62, rec[0].(int64))
 	})
 
 	t.Run("simple string", func(t *testing.T) {


### PR DESCRIPTION
Now uses the 8, 16, 32 bit record types, and also float64, and []byte.